### PR TITLE
Fix typo in Node.js feature test

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,7 +221,7 @@ body.unsupported .supported {
 }</code></pre>
         <p>And in Node.js, you would do something like the following:</p>
         <pre><code class="javascript">(function(exports){
-  if(&quot;Intl&quot; in window){
+  if(&quot;Intl&quot; in exports){
     console.log(&quot;Sweet! Lets localize!&quot;)
   } 
 }(this)); //assuming this is the global scope


### PR DESCRIPTION
There is no global `window` object in Node.
